### PR TITLE
Making omnisendApi protected to let the class being subclassable

### DIFF
--- a/src/Omnisend.php
+++ b/src/Omnisend.php
@@ -11,14 +11,14 @@
 
 class Omnisend
 {
-    private $apiKey;
-    private $apiUrl = 'https://api.omnisend.com/v3/';
-    private $timeout;
-    private $numberOfCurlRepeats = 0;
-    private $verifySSL = true;
-    private $lastError = array();
-    private $useCurl = true;
-    private $version = "1.2";
+    protected $apiKey;
+    protected $apiUrl = 'https://api.omnisend.com/v3/';
+    protected $timeout;
+    protected $numberOfCurlRepeats = 0;
+    protected $verifySSL = true;
+    protected $lastError = array();
+    protected $useCurl = true;
+    protected $version = "1.2";
 
     public function __construct($apiKey, $options = array())
     {

--- a/src/Omnisend.php
+++ b/src/Omnisend.php
@@ -191,7 +191,7 @@ class Omnisend
         return $this->omnisendApi($endpoint, 'DELETE', '', $queryParams);
     }
 
-    private function omnisendApi($endpoint, $method = "POST", $fields = array(), $queryParams = array())
+    protected function omnisendApi($endpoint, $method = "POST", $fields = array(), $queryParams = array())
     {
         $this->numberOfCurlRepeats++;
         $this->lastError = array();
@@ -285,7 +285,7 @@ class Omnisend
             );
         } else {
             if ($this->numberOfCurlRepeats == 1 && ($status == 408 || $status == 429 || $status == 503)) {
-                $result = self::omnisendApi($endpoint, $method, $fields, $queryParams);
+                $result = $this->omnisendApi($endpoint, $method, $fields, $queryParams);
             } elseif ($status >= 200 && $status < 300) {
                 if ($response && !empty($response)) {
                     return json_decode($response, true);


### PR DESCRIPTION
In my use case I would like to subclass \Omnisend and redefine \Omnisend::omnisendApi so I might able to add logging functionality in a single place like this:

```php
class LoggableOmnisend extends \Omnisend
{
    protected $logger;

    protected function omnisendApi($endpoint, $method = "POST", $fields = array(), $queryParams = array())
    {
        $response = parent::omnisendApi($endpoint, $method, $fields, $queryParams);

        if ($this->logger) {
            $this->logger->debug("Ominisend $method $endpoint", [
                'fields' => $fields,
                'query' => $queryParams,
                'response' => $response,
                'error' => $this->lastError(),
            ]);
        }

        return $response;
    }
}
```