### PR TITLE
Add curlOptions to override hardcoded defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require_once("vendor/autoload.php");
 Download the `Omnisend.php` file and include it manually:
 
 ```php
-require_once('Omnisend.php'); 
+require_once('Omnisend.php');
 ```
 **Note:** check and correct if needed "Omnisend.php" path.
 
@@ -43,7 +43,8 @@ Available methods & options
 ```php
 $options = array(
     'timeout' => 30,
-    'verifySSL' => false
+    'verifySSL' => false,
+    'curlOptions' => array()
 );
 $omnisend = new Omnisend('API-KEY', $options);
 ```
@@ -54,6 +55,7 @@ Available options:
 |---|---|---|
 |timeout|int|Timeout. If not passed - will be calculated depending on PHP max_execution_time
 |verifySSL|bool|Default - true. Enable (true) or disable (false) SSL verification.
+|curlOptions|array|array of CURLOPT_* of options passed to `curl_setopt_array()`
 
 **Available methods**
 
@@ -131,10 +133,10 @@ $omnisend = new Omnisend('your-api-key');
 $contacts = $omnisend->post(
   'contacts',
    array(
-       "email" => "vanessa.kensington@example.com", 
-       "firstName" => "Vanessa", 
-       "lastName" => "Kensington", 
-       "status" => "subscribed", 
+       "email" => "vanessa.kensington@example.com",
+       "firstName" => "Vanessa",
+       "lastName" => "Kensington",
+       "status" => "subscribed",
        "statusDate" => "2018-12-11T10:29:43+00:00"
     )
 );
@@ -146,7 +148,7 @@ if ($contacts) {
     //request was successful
 
     //print response
-    print_r($contacts); 
+    print_r($contacts);
     //get contactID from response
     $contactID = $contacts['contactID'];
 } else {

--- a/src/Omnisend.php
+++ b/src/Omnisend.php
@@ -18,6 +18,7 @@ class Omnisend
     private $verifySSL = true;
     private $lastError = array();
     private $useCurl = true;
+    private $curlOptions = array();
     private $version = "1.2";
 
     public function __construct($apiKey, $options = array())
@@ -43,6 +44,10 @@ class Omnisend
 
             if (array_key_exists("timeout", $options) && is_int($options['timeout'])) {
                 $this->timeout = $options['timeout'];
+            }
+
+            if (array_key_exists("curlOptions", $options) && is_array($options['curlOptions'])) {
+                $this->curlOptions = $options['curlOptions'];
             }
         }
     }
@@ -225,6 +230,11 @@ class Omnisend
             curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verifySSL);
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+            if (!empty($this->curlOptions)) {
+                curl_setopt_array($ch, $this->curlOptions);
+            }
+
             switch ($method) {
                 case "POST":
                     curl_setopt($ch, CURLOPT_POST, true);


### PR DESCRIPTION
This proposal enables the supply, or overriding of additional curl parameters via `$options['curlOptions']`, such as the connect timeout that is currently hardcoded to 5seconds.